### PR TITLE
Fix Error On 1.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ decentholograms = "2.8.8"
 fancyholograms = "2.2.0"
 worldguard = "7.0.10"
 oraxen = "1.171.0"
-nbtapi = "2.13.0"
+nbtapi = "2.13.1-SNAPSHOT"
 vault = "1.7.1"
 
 # Paper


### PR DESCRIPTION
Update NBT-API to Support 1.21.
This should remove the error displayed when using the voucher give command.