### PR TITLE
Add native Nexo integration via nexo-item field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ run/
 
 ### Output
 jars/
+
+### Claude / AI
+.claude/
+CLAUDE.md

--- a/paper/src/main/java/com/badbones69/crazyvouchers/api/objects/Voucher.java
+++ b/paper/src/main/java/com/badbones69/crazyvouchers/api/objects/Voucher.java
@@ -9,6 +9,7 @@ import com.badbones69.crazyvouchers.api.enums.config.Messages;
 import com.badbones69.crazyvouchers.api.enums.misc.PermissionKeys;
 import com.badbones69.crazyvouchers.api.enums.misc.PersistentKeys;
 import com.badbones69.crazyvouchers.api.events.VoucherRedeemEvent;
+import com.badbones69.crazyvouchers.support.NexoSupport;
 import com.badbones69.crazyvouchers.utils.ItemUtils;
 import com.ryderbelserion.fusion.core.api.constants.ModSupport;
 import com.ryderbelserion.fusion.core.api.enums.Level;
@@ -45,6 +46,11 @@ public class Voucher {
     private final CrazyManager crazyManager = this.plugin.getCrazyManager();
 
     private final ItemBuilder itemBuilder;
+
+    private final String nexoItemId;
+    private final List<String> nexoOverrideLore;
+    private final String nexoOverrideGlowing;
+    private final int nexoOverrideCustomModelData;
 
     private final String cleanName;
     private final String name;
@@ -95,6 +101,7 @@ public class Voucher {
     private final Map<UUID, Long> cooldowns = new HashMap<>();
 
     private final List<ItemBuilder> items;
+    private List<ItemStack> nexoPrizeItems;
 
     private final String requiredPlaceholdersMessage;
 
@@ -112,6 +119,11 @@ public class Voucher {
 
         this.hasCooldown = section.getBoolean("cooldown.toggle", false);
         this.cooldownInterval = section.getInt("cooldown.interval", 5);
+
+        this.nexoItemId = section.getString("nexo-item", "");
+        this.nexoOverrideLore = section.isList("lore") ? section.getStringList("lore") : List.of();
+        this.nexoOverrideGlowing = section.getString("glowing", "none");
+        this.nexoOverrideCustomModelData = section.getInt("custom-model-data", -1);
 
         String material = section.getString("item", "stone").toLowerCase();
         String model_data = "";
@@ -176,8 +188,10 @@ public class Voucher {
 
         if (this.config.getProperty(ConfigKeys.use_different_items_layout) && !section.isList("items")) {
             this.items = ItemUtils.convertConfigurationSection(section.getConfigurationSection("items"));
+            this.nexoPrizeItems = ItemUtils.convertNexoItems(section.getConfigurationSection("items"));
         } else {
             this.items = ItemUtils.convertStringList(section.getStringList("items"));
+            this.nexoPrizeItems = List.of();
         }
 
         this.usedMessage = getMessage(section, "options.message", "");
@@ -477,6 +491,10 @@ public class Voucher {
             Methods.addItem(player, itemStack.asItemStack(player));
         }
 
+        for (final ItemStack nexoItem : this.nexoPrizeItems) {
+            Methods.addItem(player, nexoItem);
+        }
+
         if (playSounds()) {
             for (final Sound sound : getSounds()) {
                 player.playSound(player.getLocation(), sound, SoundCategory.PLAYERS, getVolume(), getPitch());
@@ -573,6 +591,22 @@ public class Voucher {
     private @NotNull final SettingsManager config = ConfigManager.getConfig();
     
     public ItemStack buildItem(@NotNull final Player player, final int amount) {
+        if (!this.nexoItemId.isEmpty() && NexoSupport.isAvailable()) {
+            final ItemStack nexoItem = NexoSupport.buildItem(
+                    this.nexoItemId,
+                    this.nexoOverrideLore,
+                    this.nexoOverrideGlowing,
+                    this.nexoOverrideCustomModelData,
+                    amount
+            );
+
+            if (nexoItem != null) {
+                setUniqueId(nexoItem);
+                nexoItem.editPersistentDataContainer(container -> container.set(PersistentKeys.voucher_item.getNamespacedKey(), PersistentDataType.STRING, getStrippedName()));
+                return nexoItem;
+            }
+        }
+
         this.itemBuilder.setAmount(amount);
 
         final ItemStack item = this.itemBuilder.build().asItemStack(player);
@@ -599,6 +633,25 @@ public class Voucher {
     }
     
     public ItemStack buildItem(@NotNull final Player player, @NotNull final String argument, final int amount) {
+        if (!this.nexoItemId.isEmpty() && NexoSupport.isAvailable()) {
+            final ItemStack nexoItem = NexoSupport.buildItem(
+                    this.nexoItemId,
+                    this.nexoOverrideLore,
+                    this.nexoOverrideGlowing,
+                    this.nexoOverrideCustomModelData,
+                    amount
+            );
+
+            if (nexoItem != null) {
+                setUniqueId(nexoItem);
+                nexoItem.editPersistentDataContainer(container -> {
+                    container.set(PersistentKeys.voucher_item.getNamespacedKey(), PersistentDataType.STRING, getStrippedName());
+                    if (!argument.isEmpty()) container.set(PersistentKeys.voucher_arg.getNamespacedKey(), PersistentDataType.STRING, argument);
+                });
+                return nexoItem;
+            }
+        }
+
         final ItemStack item = this.itemBuilder.setAmount(amount).addPlaceholder("{arg}", argument).asItemStack(player);
 
         setUniqueId(item);

--- a/paper/src/main/java/com/badbones69/crazyvouchers/support/NexoSupport.java
+++ b/paper/src/main/java/com/badbones69/crazyvouchers/support/NexoSupport.java
@@ -1,0 +1,60 @@
+package com.badbones69.crazyvouchers.support;
+
+import com.nexomc.nexo.api.NexoItems;
+import com.nexomc.nexo.items.ItemBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import java.util.List;
+
+public class NexoSupport {
+
+    private static final MiniMessage MM = MiniMessage.miniMessage();
+
+    public static boolean isAvailable() {
+        return Bukkit.getPluginManager().isPluginEnabled("Nexo");
+    }
+
+    /**
+     * Builds an ItemStack from a Nexo item ID, applying optional overrides from CrazyVouchers config.
+     * A non-empty overrideLore replaces the Nexo lore; glowing/customModelData are applied only when not at their
+     * "unset" sentinel values ("none" and -1 respectively).
+     *
+     * @return the built ItemStack, or null if the ID doesn't exist in Nexo (triggers fallback).
+     */
+    public static @Nullable ItemStack buildItem(@NotNull final String nexoId,
+                                                @NotNull final List<String> overrideLore,
+                                                @NotNull final String overrideGlowing,
+                                                final int overrideCustomModelData,
+                                                final int amount) {
+        final ItemBuilder builder = NexoItems.itemFromId(nexoId);
+
+        if (builder == null) return null;
+
+        if (!overrideLore.isEmpty()) {
+            final List<Component> components = overrideLore.stream()
+                    .map(MM::deserialize)
+                    .toList();
+            builder.lore(components);
+        }
+
+        switch (overrideGlowing.toLowerCase()) {
+            case "add_glow", "true" -> builder.setEnchantmentGlintOverride(true);
+            case "remove_glow", "false" -> builder.setEnchantmentGlintOverride(false);
+            default -> {}
+        }
+
+        if (overrideCustomModelData != -1) {
+            builder.customModelData(overrideCustomModelData);
+        }
+
+        final ItemStack item = builder.build();
+
+        if (item != null) item.setAmount(amount);
+
+        return item;
+    }
+}

--- a/paper/src/main/java/com/badbones69/crazyvouchers/utils/ItemUtils.java
+++ b/paper/src/main/java/com/badbones69/crazyvouchers/utils/ItemUtils.java
@@ -1,6 +1,7 @@
 package com.badbones69.crazyvouchers.utils;
 
 import com.badbones69.crazyvouchers.CrazyVouchers;
+import com.badbones69.crazyvouchers.support.NexoSupport;
 import com.ryderbelserion.fusion.core.api.enums.Level;
 import com.ryderbelserion.fusion.core.utils.StringUtils;
 import com.ryderbelserion.fusion.paper.FusionPaper;
@@ -11,6 +12,7 @@ import com.ryderbelserion.fusion.paper.builders.items.types.SkullBuilder;
 import com.ryderbelserion.fusion.paper.builders.items.types.custom.CustomBuilder;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ItemType;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
@@ -267,6 +269,39 @@ public class ItemUtils {
      */
     public static List<ItemBuilder> convertStringList(@NotNull final List<String> itemStrings, @NotNull final String placeholder) {
         return itemStrings.stream().map(itemString -> convertString(itemString, placeholder)).collect(Collectors.toList());
+    }
+
+    /**
+     * Extracts Nexo prize items from a YAML items section (use_different_items_layout mode).
+     * Only processes entries that have a "nexo-item" key defined.
+     */
+    public static List<ItemStack> convertNexoItems(@Nullable final ConfigurationSection section) {
+        final List<ItemStack> cache = new ArrayList<>();
+
+        if (section == null || !NexoSupport.isAvailable()) return cache;
+
+        for (final String key : section.getKeys(false)) {
+            final ConfigurationSection item = section.getConfigurationSection(key);
+
+            if (item == null) continue;
+
+            final String nexoId = item.getString("nexo-item", "");
+
+            if (nexoId.isEmpty()) continue;
+
+            final List<String> overrideLore = item.isList("lore") ? item.getStringList("lore") : List.of();
+            final int amount = item.getInt("amount", 1);
+
+            final ItemStack nexoItem = NexoSupport.buildItem(nexoId, overrideLore, "none", -1, amount);
+
+            if (nexoItem != null) {
+                cache.add(nexoItem);
+            } else {
+                fusion.log(Level.WARNING, "Nexo item '%s' not found, skipping prize item.", nexoId);
+            }
+        }
+
+        return cache;
     }
 
     public static String getEnchant(@NotNull final String enchant) {

--- a/paper/src/main/resources/vouchers/Nexo-Example.yml
+++ b/paper/src/main/resources/vouchers/Nexo-Example.yml
@@ -1,0 +1,47 @@
+voucher:
+  # The vanilla material used as fallback when Nexo is not installed.
+  item: 'paper'
+  # The Nexo item ID. When set, the voucher item is built directly from Nexo,
+  # inheriting its lore, tooltip, model and other attributes.
+  nexo-item: 'your_nexo_item_id'
+  # Leave lore empty to inherit the lore from Nexo.
+  # Add lines here to override Nexo's lore entirely.
+  lore: []
+  # "none" leaves Nexo's enchant glint untouched.
+  # "add_glow" / "remove_glow" override it.
+  glowing: "none"
+  # -1 leaves Nexo's custom-model-data untouched.
+  custom-model-data: -1
+  override-anti-dupe: false
+  allow-vouchers-in-item-frames: false
+  commands:
+    - 'msg {player} You claimed a Nexo voucher!'
+  # Items to give when redeeming the voucher.
+  # When use-different-items-layout is true in config.yml, you can also
+  # specify nexo-item here to give a Nexo item as a prize.
+  items: []
+  options:
+    message: '<gray>Congratulations, you claimed a Nexo item!'
+    whitelist-worlds:
+      toggle: false
+      worlds:
+        - 'world'
+    permission:
+      whitelist-permission:
+        toggle: false
+        permissions:
+          - 'your-permission'
+    limiter:
+      toggle: false
+      amount: 10
+    two-step-authentication: false
+    sound:
+      toggle: true
+      volume: 1.0
+      pitch: 1.0
+      sounds:
+        - 'block.cherry_wood_button.click_on'
+    firework:
+      toggle: true
+      colors: 'Green, Lime'
+    is-edible: false


### PR DESCRIPTION
## Summary

- Añade campo `nexo-item` al YAML del voucher: construye el ItemStack directamente desde la API de Nexo, heredando lore, tooltip style, item model, enchant glint y todos los atributos que Nexo define
- Cada atributo (lore, glowing, custom-model-data) puede sobreescribirse individualmente desde el YAML; valores vacíos/default usan los de Nexo
- Fallback automático al material `item` (vanilla) cuando Nexo no está instalado, sin errores en consola
- Nueva clase `NexoSupport` para comprobación de disponibilidad y construcción de items desde Nexo
- Soporte para items Nexo como premio en el modo `use-different-items-layout` mediante `nexo-item` dentro de `items:`
- Añade `Nexo-Example.yml` como plantilla de voucher documentando el uso
- Actualiza `.gitignore` para excluir archivos de herramientas AI

## Test Plan

- [ ] Con Nexo instalado: crear voucher con `nexo-item: <id_valido>` — el item en mano debe mostrar el lore, tooltip y modelo de Nexo
- [ ] Con `lore: ['Texto']` en el YAML — ese lore reemplaza al de Nexo
- [ ] Con `lore: []` — se usa el lore nativo de Nexo
- [ ] Sin Nexo instalado: el voucher carga usando el material de `item` sin errores en consola
- [ ] ID inválido de Nexo: el plugin loguea advertencia y usa el material de `item` como fallback
- [ ] Item de premio con `nexo-item` en el layout estructurado: se entrega correctamente al canjear
- [ ] Build de GitHub Actions pasa sin errores